### PR TITLE
Due to bintray returning 502 error, must replace repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,10 @@ version = componentNode.@version
 // to run use "gradle dependencyUpdates"
 apply plugin: 'com.github.ben-manes.versions'
 buildscript {
-  repositories { jcenter() }
+  repositories {
+      mavenCentral()
+      gradlePluginPortal()
+  }
   dependencies { classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0' }
 }
 
@@ -23,13 +26,16 @@ dependencyUpdates.resolutionStrategy = { componentSelection { rules -> rules.all
 repositories {
     flatDir name: 'frameworkLib', dirs: frameworkDir.absolutePath + '/lib'
     //flatDir name: 'localLib', dirs: projectDir.absolutePath + '/lib'
-    jcenter()
-    maven { url "http://dl.bintray.com/andimarek/graphql-java" }
+    mavenCentral()
 }
 
 dependencies {
     compile project(':framework')
+    implementation 'org.elasticsearch.client:transport:7.5.1'
+
     compile 'com.graphql-java:graphql-java:4.2'
+    compile 'org.antlr:antlr4-runtime:4.5.3'
+
     testCompile project(':framework').configurations.testCompile.allDependencies
 }
 
@@ -71,3 +77,4 @@ test {
 
     beforeTest { descriptor -> logger.lifecycle("Running test: ${descriptor}") }
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ repositories {
 
 dependencies {
     compile project(':framework')
-    compile project(":runtime:component:moqui-elasticsearch")
     compile 'com.graphql-java:graphql-java:4.2'
     testCompile project(':framework').configurations.testCompile.allDependencies
 }
@@ -66,7 +65,7 @@ test {
     // show standard out and standard error of the test JVM(s) on the console
     testLogging.showStandardStreams = true; testLogging.showExceptions = true
 
-    classpath += files(sourceSets.main.output.classesDir)
+    classpath += files(sourceSets.main.output.classesDirs)
     // filter out classpath entries that don't exist (gradle adds a bunch of these), or ElasticSearch JarHell will blow up
     classpath = classpath.filter { it.exists() }
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,8 @@ repositories {
 
 dependencies {
     compile project(':framework')
-    implementation 'org.elasticsearch.client:transport:7.5.1'
 
     compile 'com.graphql-java:graphql-java:4.2'
-    compile 'org.antlr:antlr4-runtime:4.5.3'
 
     testCompile project(':framework').configurations.testCompile.allDependencies
 }
@@ -77,4 +75,3 @@ test {
 
     beforeTest { descriptor -> logger.lifecycle("Running test: ${descriptor}") }
 }
-

--- a/component.xml
+++ b/component.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/moqui-conf-2.0.xsd"
         name="moqui-graphql" version="0.2">
-    <depends-on name="moqui-elasticsearch"/>
 </component>

--- a/src/main/groovy/com/moqui/impl/service/fetcher/EntityBatchedDataFetcher.groovy
+++ b/src/main/groovy/com/moqui/impl/service/fetcher/EntityBatchedDataFetcher.groovy
@@ -132,7 +132,7 @@ class EntityBatchedDataFetcher extends BaseEntityDataFetcher implements BatchedD
                     jointValueList = mergeWithInterfaceValue(ec, efConcrete.list().getValueMapList())
 
                 } else {
-                    jointValueList = new ArrayList<>(sourceItemCount)
+                    jointValueList = new ArrayList<Map<String, Object>>(sourceItemCount)
                     ((List) environment.source).eachWithIndex { Object object, int index ->
                         Map sourceItem = (Map) object
                         EntityFind efConcrete = ec.entity.find(entityName).useCache(useCache)
@@ -147,7 +147,7 @@ class EntityBatchedDataFetcher extends BaseEntityDataFetcher implements BatchedD
                     Map sourceItem = (Map) object
 
                     jointOneMap = (relKeyCount == 0 ? (jointValueList.size() > 0 ? jointValueList[0] : null) :
-                            jointValueList.find { Object it -> DataFetcherUtils.matchParentByRelKeyMap(sourceItem, it as Map<String, Object>, relKeyMap) }) as Map<String, Object>
+                            (Map<String, Object>)jointValueList.find { Object it -> DataFetcherUtils.matchParentByRelKeyMap(sourceItem, it as Map<String, Object>, relKeyMap) })
 
                     if (jointOneMap == null) return
                     cursor = GraphQLSchemaUtil.encodeRelayCursor(jointOneMap, pkFieldNames)
@@ -183,7 +183,7 @@ class EntityBatchedDataFetcher extends BaseEntityDataFetcher implements BatchedD
 
                         }
                         edgesDataList = matchedJointValueList.collect { Object it ->
-                            Map<String, Object> matchedJointOneMap = it as Map<String, Object>
+                            Map<String, Object> matchedJointOneMap = (Map<String, Object>)it
                             edgesData = new HashMap<>(2)
                             cursor = GraphQLSchemaUtil.encodeRelayCursor(matchedJointOneMap, pkFieldNames)
 
@@ -213,7 +213,7 @@ class EntityBatchedDataFetcher extends BaseEntityDataFetcher implements BatchedD
 
                         if (!ef.getLimit()) ef.limit(100)
 
-                        int count = ef.count() as int
+                        int count = (int)ef.count()
                         int pageIndex = ef.getPageIndex()
                         int pageSize = ef.getPageSize()
                         int pageMaxIndex = ((count - 1) as BigDecimal).divide(pageSize as BigDecimal, 0, BigDecimal.ROUND_DOWN).intValue()


### PR DESCRIPTION
dl.bintray.com is returning a 502 error [see here](http://dl.bintray.com/andimarek/graphql-java/org/codehaus/btm/btm/3.0.0-SNAPSHOT/maven-metadata.xml)

The bintray service has been sunsetted [according to their website](https://status.bintray.com/). 

I was getting this error:
```
> Task :runtime:component:moqui-graphql:compileGroovy FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':runtime:component:moqui-graphql:compileGroovy'.
> Could not resolve all files for configuration ':runtime:component:moqui-graphql:compileClasspath'.
   > Could not resolve org.codehaus.btm:btm:3.0.0-SNAPSHOT.
     Required by:
         project :runtime:component:moqui-graphql > project :framework
      > Could not resolve org.codehaus.btm:btm:3.0.0-SNAPSHOT.
         > Unable to load Maven meta-data from http://dl.bintray.com/andimarek/graphql-java/org/codehaus/btm/btm/3.0.0-SNAPSHOT/maven-metadata.xml.
            > Could not get resource 'http://dl.bintray.com/andimarek/graphql-java/org/codehaus/btm/btm/3.0.0-SNAPSHOT/maven-metadata.xml'.
               > Could not GET 'http://dl.bintray.com/andimarek/graphql-java/org/codehaus/btm/btm/3.0.0-SNAPSHOT/maven-metadata.xml'. Received status code 502 from server: Bad Gateway
```

This change fixes the dependencies by remove the `jcenter()` repository, and replacing it with `mavenCentral()`. `mavenCentral()` doesn't have `com.github.ben-manes:gradle-versions-plugin:0.13.0`, but `gradlePluginPortal()` does, so that's why it was added. 