### PR TITLE
Due to bintray returning 502 error, must replace repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,10 @@ version = componentNode.@version
 // to run use "gradle dependencyUpdates"
 apply plugin: 'com.github.ben-manes.versions'
 buildscript {
-  repositories { jcenter() }
+  repositories {
+      mavenCentral()
+      gradlePluginPortal()
+  }
   dependencies { classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0' }
 }
 
@@ -23,8 +26,7 @@ dependencyUpdates.resolutionStrategy = { componentSelection { rules -> rules.all
 repositories {
     flatDir name: 'frameworkLib', dirs: frameworkDir.absolutePath + '/lib'
     //flatDir name: 'localLib', dirs: projectDir.absolutePath + '/lib'
-    jcenter()
-    maven { url "http://dl.bintray.com/andimarek/graphql-java" }
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
dl.bintray.com is returning a 502 error [see here](http://dl.bintray.com/andimarek/graphql-java/org/codehaus/btm/btm/3.0.0-SNAPSHOT/maven-metadata.xml)

The bintray service has been sunsetted [according to their website](https://status.bintray.com/). 

I was getting this error:
```
> Task :runtime:component:moqui-graphql:compileGroovy FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':runtime:component:moqui-graphql:compileGroovy'.
> Could not resolve all files for configuration ':runtime:component:moqui-graphql:compileClasspath'.
   > Could not resolve org.codehaus.btm:btm:3.0.0-SNAPSHOT.
     Required by:
         project :runtime:component:moqui-graphql > project :framework
      > Could not resolve org.codehaus.btm:btm:3.0.0-SNAPSHOT.
         > Unable to load Maven meta-data from http://dl.bintray.com/andimarek/graphql-java/org/codehaus/btm/btm/3.0.0-SNAPSHOT/maven-metadata.xml.
            > Could not get resource 'http://dl.bintray.com/andimarek/graphql-java/org/codehaus/btm/btm/3.0.0-SNAPSHOT/maven-metadata.xml'.
               > Could not GET 'http://dl.bintray.com/andimarek/graphql-java/org/codehaus/btm/btm/3.0.0-SNAPSHOT/maven-metadata.xml'. Received status code 502 from server: Bad Gateway
```

This change fixes the dependencies by remove the `jcenter()` repository, and replacing it with `mavenCentral()`. `mavenCentral()` doesn't have `com.github.ben-manes:gradle-versions-plugin:0.13.0`, but `gradlePluginPortal()` does, so that's why it was added. 